### PR TITLE
Issue #69 - Add margin to bottom of wrapper div

### DIFF
--- a/src/components/ThemePicker.vue
+++ b/src/components/ThemePicker.vue
@@ -117,5 +117,6 @@ export default {
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  margin-bottom: 1.5em;
 }
 </style>


### PR DESCRIPTION
Add 1.5em margin-bottom to wrapper div

Screenshot:
![margin-bottom](https://user-images.githubusercontent.com/39498043/67626737-503afe80-f826-11e9-8b02-a0109c7d0928.jpg)